### PR TITLE
Add bc as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ it. This tool is able to work with a variety of image viewers like ```feh```,
 
 ## Dependencies
 - ```bash```
+- ```bc```
 - ```imagemagick```
 - ```feh``` (Other: ```mpv```, ```nsxiv``` or ```sxiv```, but you must specify it using the ```--image-viewer``` flag)
 #### If you use X11

--- a/farge
+++ b/farge
@@ -77,6 +77,8 @@ check_dependencies() {
             echo "xcolor needs to be installed" && exit 1
     fi
 
+    ! command -v bc &>/dev/null &&
+        echo "bc needs to be installed" && exit 1
     ! command -v convert &>/dev/null &&
         echo "imagemagick needs to be installed" && exit 1
 


### PR DESCRIPTION
On some systems I've found that bc is not installed, and farge fails because bc is not in PATH.

I added a check which makes sure bc is installed, and I added bc to the dependency list in the readme.

Closes #28 